### PR TITLE
Add MyBatis pipeline services

### DIFF
--- a/src/main/java/org/example/membership/dto/UserCategoryStats.java
+++ b/src/main/java/org/example/membership/dto/UserCategoryStats.java
@@ -1,0 +1,13 @@
+package org.example.membership.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+public class UserCategoryStats {
+    private long count;
+    private BigDecimal amount;
+}

--- a/src/main/java/org/example/membership/repository/mybatis/BadgeMapper.java
+++ b/src/main/java/org/example/membership/repository/mybatis/BadgeMapper.java
@@ -1,0 +1,13 @@
+package org.example.membership.repository.mybatis;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.membership.entity.Badge;
+
+import java.util.List;
+
+@Mapper
+public interface BadgeMapper {
+    List<Badge> findByUserId(@Param("userId") Long userId);
+    void update(Badge badge);
+}

--- a/src/main/java/org/example/membership/repository/mybatis/CouponIssueLogMapper.java
+++ b/src/main/java/org/example/membership/repository/mybatis/CouponIssueLogMapper.java
@@ -1,0 +1,12 @@
+package org.example.membership.repository.mybatis;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.membership.entity.CouponIssueLog;
+
+import java.util.List;
+
+@Mapper
+public interface CouponIssueLogMapper {
+    void insertAll(@Param("list") List<CouponIssueLog> logs);
+}

--- a/src/main/java/org/example/membership/service/pipeline/BadgeServiceMyBatis.java
+++ b/src/main/java/org/example/membership/service/pipeline/BadgeServiceMyBatis.java
@@ -1,0 +1,40 @@
+package org.example.membership.service.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import org.example.membership.dto.UserCategoryStats;
+import org.example.membership.entity.Badge;
+import org.example.membership.entity.User;
+import org.example.membership.repository.mybatis.BadgeMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeServiceMyBatis {
+
+    private final BadgeMapper badgeMapper;
+
+    @Transactional
+    public void updateBadgeStatesForUser(User user, Map<Long, UserCategoryStats> statsByCategory) {
+        if (statsByCategory == null) {
+            statsByCategory = Collections.emptyMap();
+        }
+        List<Badge> badges = badgeMapper.findByUserId(user.getId());
+        for (Badge badge : badges) {
+            UserCategoryStats stat = statsByCategory.get(badge.getCategory().getId());
+            if (stat != null && stat.getCount() >= 5 && stat.getAmount().compareTo(new BigDecimal("300000")) >= 0) {
+                badge.setActive(true);
+            } else {
+                badge.setActive(false);
+            }
+            badge.setUpdatedAt(LocalDateTime.now());
+            badgeMapper.update(badge);
+        }
+    }
+}

--- a/src/main/java/org/example/membership/service/pipeline/CouponLogServiceMyBatis.java
+++ b/src/main/java/org/example/membership/service/pipeline/CouponLogServiceMyBatis.java
@@ -1,0 +1,37 @@
+package org.example.membership.service.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import org.example.membership.entity.Coupon;
+import org.example.membership.entity.CouponIssueLog;
+import org.example.membership.entity.User;
+import org.example.membership.repository.mybatis.CouponIssueLogMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CouponLogServiceMyBatis {
+
+    private final CouponIssueLogMapper couponIssueLogMapper;
+
+    @Transactional
+    public void saveAll(List<CouponIssueLog> logs) {
+        couponIssueLogMapper.insertAll(logs);
+    }
+
+    @Transactional
+    public void insertCouponLogs(User user, List<Coupon> coupons) {
+        List<CouponIssueLog> logs = new java.util.ArrayList<>();
+        for (Coupon coupon : coupons) {
+            CouponIssueLog log = new CouponIssueLog();
+            log.setUser(user);
+            log.setCoupon(coupon);
+            log.setMembershipLevel(user.getMembershipLevel());
+            log.setIssuedAt(java.time.LocalDateTime.now());
+            logs.add(log);
+        }
+        couponIssueLogMapper.insertAll(logs);
+    }
+}

--- a/src/main/java/org/example/membership/service/pipeline/CouponServiceMyBatis.java
+++ b/src/main/java/org/example/membership/service/pipeline/CouponServiceMyBatis.java
@@ -1,0 +1,55 @@
+package org.example.membership.service.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import org.example.membership.common.enums.CouponAmount;
+import org.example.membership.entity.Badge;
+import org.example.membership.entity.Coupon;
+import org.example.membership.entity.User;
+import org.example.membership.repository.mybatis.BadgeMapper;
+import org.example.membership.repository.mybatis.CouponMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CouponServiceMyBatis {
+
+    private final CouponMapper couponMapper;
+    private final BadgeMapper badgeMapper;
+
+    @Transactional
+    public void createCoupons(List<Coupon> coupons) {
+        for (Coupon coupon : coupons) {
+            couponMapper.insert(coupon);
+        }
+    }
+
+    @Transactional
+    public List<Coupon> issueCoupons(User user) {
+        int qty = switch (user.getMembershipLevel()) {
+            case VIP -> 3;
+            case GOLD -> 2;
+            case SILVER -> 1;
+            default -> 0;
+        };
+        List<Coupon> issued = new ArrayList<>();
+        if (qty == 0) return issued;
+        List<Badge> badges = badgeMapper.findByUserId(user.getId());
+        for (Badge badge : badges) {
+            if (!badge.isActive()) continue;
+            for (int i = 0; i < qty; i++) {
+                Coupon c = new Coupon();
+                c.setCode("AUTO-" + UUID.randomUUID().toString().substring(0, 8));
+                c.setDiscountAmount(CouponAmount.W1000);
+                c.setCategory(badge.getCategory());
+                couponMapper.insert(c);
+                issued.add(c);
+            }
+        }
+        return issued;
+    }
+}

--- a/src/main/java/org/example/membership/service/pipeline/MembershipLogServiceMyBatis.java
+++ b/src/main/java/org/example/membership/service/pipeline/MembershipLogServiceMyBatis.java
@@ -1,0 +1,35 @@
+package org.example.membership.service.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import org.example.membership.dto.MembershipLogRequest;
+import org.example.membership.common.enums.MembershipLevel;
+import org.example.membership.entity.MembershipLog;
+import org.example.membership.entity.User;
+import org.example.membership.repository.mybatis.MembershipLogMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipLogServiceMyBatis {
+
+    private final MembershipLogMapper membershipLogMapper;
+
+    @Transactional
+    public void saveAll(List<MembershipLogRequest> logs) {
+        membershipLogMapper.bulkInsertRequests(logs);
+    }
+
+    @Transactional
+    public void insertMembershipLog(User user, MembershipLevel previousLevel) {
+        MembershipLog log = new MembershipLog();
+        log.setUser(user);
+        log.setPreviousLevel(previousLevel);
+        log.setNewLevel(user.getMembershipLevel());
+        log.setChangeReason("badge count: " + user.getMembershipLevel());
+        log.setChangedAt(java.time.LocalDateTime.now());
+        membershipLogMapper.insert(log);
+    }
+}

--- a/src/main/java/org/example/membership/service/pipeline/MembershipServiceMyBatis.java
+++ b/src/main/java/org/example/membership/service/pipeline/MembershipServiceMyBatis.java
@@ -1,0 +1,50 @@
+package org.example.membership.service.pipeline;
+
+import lombok.RequiredArgsConstructor;
+import org.example.membership.common.enums.MembershipLevel;
+import org.example.membership.entity.User;
+import org.example.membership.entity.Badge;
+import org.example.membership.repository.mybatis.BadgeMapper;
+import org.example.membership.repository.mybatis.UserMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipServiceMyBatis {
+
+    private final UserMapper userMapper;
+    private final BadgeMapper badgeMapper;
+
+    @Transactional
+    public void updateUserLevels(List<User> users) {
+        userMapper.bulkUpdateMembershipLevels(users);
+    }
+
+    @Transactional
+    public MembershipLevel updateUserLevel(User user) {
+        long activeCount = badgeMapper.findByUserId(user.getId())
+                .stream()
+                .filter(Badge::isActive)
+                .count();
+        MembershipLevel prev = user.getMembershipLevel();
+        MembershipLevel newLevel = calculateLevel(activeCount);
+        user.setMembershipLevel(newLevel);
+        user.setLastMembershipChange(java.time.LocalDateTime.now());
+        userMapper.update(user);
+        return prev;
+    }
+
+    public MembershipLevel calculateLevel(long badgeCount) {
+        if (badgeCount >= 3) {
+            return MembershipLevel.VIP;
+        } else if (badgeCount == 2) {
+            return MembershipLevel.GOLD;
+        } else if (badgeCount == 1) {
+            return MembershipLevel.SILVER;
+        }
+        return MembershipLevel.NONE;
+    }
+}

--- a/src/main/resources/mapper/BadgeMapper.xml
+++ b/src/main/resources/mapper/BadgeMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.example.membership.repository.mybatis.BadgeMapper">
+
+    <resultMap id="badgeResultMap" type="org.example.membership.entity.Badge">
+        <id property="id" column="id"/>
+        <result property="active" column="active"/>
+        <result property="updatedAt" column="updated_at"/>
+        <association property="user" javaType="org.example.membership.entity.User">
+            <id property="id" column="user_id"/>
+        </association>
+        <association property="category" javaType="org.example.membership.entity.Category">
+            <id property="id" column="category_id"/>
+        </association>
+    </resultMap>
+
+    <select id="findByUserId" resultMap="badgeResultMap">
+        SELECT * FROM badges WHERE user_id = #{userId}
+    </select>
+
+    <update id="update" parameterType="org.example.membership.entity.Badge">
+        UPDATE badges
+        SET active = #{active},
+            updated_at = #{updatedAt},
+            category_id = #{category.id}
+        WHERE id = #{id}
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/CouponIssueLogMapper.xml
+++ b/src/main/resources/mapper/CouponIssueLogMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.example.membership.repository.mybatis.CouponIssueLogMapper">
+
+    <insert id="insertAll" parameterType="java.util.List">
+        INSERT INTO coupon_issue_log (
+            user_id,
+            coupon_id,
+            membership_level,
+            issued_at
+        )
+        VALUES
+        <foreach collection="list" item="log" separator=",">
+            (
+            #{log.user.id},
+            #{log.coupon.id},
+            #{log.membershipLevel},
+            #{log.issuedAt}
+            )
+        </foreach>
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## Summary
- add UserCategoryStats DTO
- implement MyBatis service implementations for badge, membership, coupon, and log handling
- create mappers for Badge and CouponIssueLog with XML mappings
- inject the MyBatis services in `MyBatisRenewalPipelineService`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6858ce7a4e948327bec91111c22e526f